### PR TITLE
Update fopen.c

### DIFF
--- a/Chapter 8/8-2/fields/fopen.c
+++ b/Chapter 8/8-2/fields/fopen.c
@@ -25,7 +25,7 @@ FILE *fopen(char *name, char *mode)
     if (*mode != 'r' && *mode != 'w' && *mode != 'a')
         return NULL;
     for (fp = _iob; fp < _iob + OPEN_MAX; fp++)
-        if (fp->flags.read == 0 || fp->flags.write == 0)
+        if (fp->flags.read == 0 && fp->flags.write == 0)
             break;        /* found free slot */
     if (fp >= _iob + OPEN_MAX)    /* no free slots */
         return NULL;


### PR DESCRIPTION
In Exercise 8-2, fopen.c:
Original Line 28:        if (fp->flags.read == 0 || fp->flags.write == 0)
Suggested Line 28:   if (fp->flags.read == 0 && fp->flags.write == 0)

I think logical AND, instead of OR, should be used.
KR's original line had:       if (fp->flag & (_READ | _WRITE)) == 0)
i.e. condition should pass if and only if fp->flag has both its _READ and _WRITE bits off. otherwise, (fp->flag & (_READ | _WRITE)) has a non-zero bit and is not equal to zero, so condition fails.